### PR TITLE
prevent php error if group has no fields

### DIFF
--- a/bp-conditional-profile-fields.php
+++ b/bp-conditional-profile-fields.php
@@ -128,6 +128,11 @@ class Devb_Conditional_Xprofile_Field_Helper {
 
 		foreach ( $groups as $group ) {
 
+			// skip if group has no profile fields
+			if ( empty( $group->fields ) ) {
+				continue;
+			} 
+
 			foreach ( $group->fields as $field ) {
 				
 				


### PR DESCRIPTION
Prevent foreach warning if group has no fields.
