### PR TITLE
Don't duplicate field groups.

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -315,10 +315,11 @@ class Devb_Conditional_Profile_Admin{
             
             $html .= "</optgroup>"; 
             
-            echo $html;
             //$this->fields_info[]
             
         }
+
+        echo $html;
     }
     
 	/**


### PR DESCRIPTION
Fix for duplicate field groups showing up in the field editor.

See Also: Issue #5 